### PR TITLE
Refactor: improvements to APIClient

### DIFF
--- a/ESAssignment/Service/APIClient.swift
+++ b/ESAssignment/Service/APIClient.swift
@@ -20,24 +20,16 @@ final class APIClient: APIClientProtocol {
     }
 
     func requestMedia(searchText: String, page: Int, apiKey: String) -> AnyPublisher<MediaResponse, Error> {
-        Future<MediaResponse, Error> { promise in
-            self.provider.requestPublisher(.searchMovies(searchText: searchText, page: page, apiKey: apiKey))
-                .sink { result in
-                    switch result {
-                    case .failure(let error):
-                        promise(.failure(error))
-                    default:
-                        break
-                    }
-                } receiveValue: { response in
-                    do {
-                        let result = try JSONDecoder().decode(MediaResponse.self, from: response.data)
-                        promise(.success(result))
-                    } catch let err {
-                        promise(.failure(err))
-                    }
-                }
-                .store(in: &self.cancellable)
-        }.eraseToAnyPublisher()
+        return provider.request(.searchMovies(searchText: searchText, page: page, apiKey: apiKey))
+    }
+}
+
+extension MoyaProvider {
+    func request<T:Decodable>(_ target:Target) -> AnyPublisher<T, Error> {
+        return self.requestPublisher(target)
+            .map(T.self)
+            .catch({ error in
+                Fail(error: error)
+            }).eraseToAnyPublisher()
     }
 }

--- a/ESAssignmentTests/MediaViewModelTests.swift
+++ b/ESAssignmentTests/MediaViewModelTests.swift
@@ -11,7 +11,7 @@ final class MediaViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.cancellables = []
-        self.apiClient = APIClient(mock: true)
+        self.apiClient = APIClient(stub: true)
         self.viewModel = MediaViewModel(apiClient: apiClient!)
     }
 


### PR DESCRIPTION
# Description

Improvements to APIClient in order to make the previous declared method requestMedia less verbose, adding some reusability through declaration of an extension for MoyaProvider with generic types to assist in mapping objects.

## Type of change

Please delete options that are not relevant.

- [x] Refactor (non-breaking change that improves existing codebase)

# Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

