### PR TITLE
Test: Improvements to MediaViewModel tests

### DIFF
--- a/ESAssignment.xcodeproj/project.pbxproj
+++ b/ESAssignment.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		A8B090FC2BEE1FF70048A17C /* ErrorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B090FB2BEE1FF70048A17C /* ErrorCell.swift */; };
 		A8B091062BEE6B680048A17C /* BuilderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B091052BEE6B680048A17C /* BuilderProtocol.swift */; };
 		A8B091082BEE6B8B0048A17C /* MediaViewControllerBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B091072BEE6B8B0048A17C /* MediaViewControllerBuilder.swift */; };
+		A8C597BD2BFDCF49005B2146 /* APIClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C597BC2BFDCF49005B2146 /* APIClientMock.swift */; };
+		A8C597BF2BFDCF60005B2146 /* MediaViewModelSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C597BE2BFDCF60005B2146 /* MediaViewModelSpy.swift */; };
 		A8D897002BED393B0011BA9A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D896FF2BED393B0011BA9A /* APIClient.swift */; };
 		A8D897022BED39630011BA9A /* OMDbProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D897012BED39630011BA9A /* OMDbProvider.swift */; };
 		A8D897052BED3BA80011BA9A /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D897042BED3BA80011BA9A /* Media.swift */; };
@@ -64,6 +66,8 @@
 		A8B090FB2BEE1FF70048A17C /* ErrorCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorCell.swift; sourceTree = "<group>"; };
 		A8B091052BEE6B680048A17C /* BuilderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuilderProtocol.swift; sourceTree = "<group>"; };
 		A8B091072BEE6B8B0048A17C /* MediaViewControllerBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewControllerBuilder.swift; sourceTree = "<group>"; };
+		A8C597BC2BFDCF49005B2146 /* APIClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientMock.swift; sourceTree = "<group>"; };
+		A8C597BE2BFDCF60005B2146 /* MediaViewModelSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewModelSpy.swift; sourceTree = "<group>"; };
 		A8D896FF2BED393B0011BA9A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		A8D897012BED39630011BA9A /* OMDbProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OMDbProvider.swift; sourceTree = "<group>"; };
 		A8D897042BED3BA80011BA9A /* Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
@@ -151,6 +155,8 @@
 			isa = PBXGroup;
 			children = (
 				A80E31302BED33CF00730EDF /* MediaViewModelTests.swift */,
+				A8C597BC2BFDCF49005B2146 /* APIClientMock.swift */,
+				A8C597BE2BFDCF60005B2146 /* MediaViewModelSpy.swift */,
 			);
 			path = ESAssignmentTests;
 			sourceTree = "<group>";
@@ -422,6 +428,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A80E31312BED33CF00730EDF /* MediaViewModelTests.swift in Sources */,
+				A8C597BD2BFDCF49005B2146 /* APIClientMock.swift in Sources */,
+				A8C597BF2BFDCF60005B2146 /* MediaViewModelSpy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ESAssignment/Feature/Media/MediaViewModel.swift
+++ b/ESAssignment/Feature/Media/MediaViewModel.swift
@@ -3,6 +3,7 @@ import UIKit
 import Combine
 
 protocol MediaViewModelProtocol {
+    var apiClient: APIClientProtocol { get }
     var media: [Media]? { get }
     var mediaPublisher: Published<[Media]?>.Publisher { get }
     var error: Error? { get }
@@ -21,7 +22,7 @@ protocol MediaViewModelProtocol {
 
 final class MediaViewModel: MediaViewModelProtocol, ObservableObject {
 
-    private let apiClient: APIClientProtocol
+    private(set) var apiClient: APIClientProtocol
 
     init(apiClient: APIClientProtocol) {
         self.apiClient = apiClient

--- a/ESAssignment/Service/APIClient.swift
+++ b/ESAssignment/Service/APIClient.swift
@@ -11,8 +11,8 @@ final class APIClient: APIClientProtocol {
 
     private let provider: MoyaProvider<OMDbProvider>
 
-    init(mock: Bool = false) {
-        if mock {
+    init(stub: Bool = false) {
+        if stub {
             self.provider = MoyaProvider<OMDbProvider>.init(stubClosure: MoyaProvider<OMDbProvider>.immediatelyStub(_:))
         } else {
             self.provider = MoyaProvider<OMDbProvider>()

--- a/ESAssignmentTests/APIClientMock.swift
+++ b/ESAssignmentTests/APIClientMock.swift
@@ -1,0 +1,17 @@
+@testable import ESAssignment
+import Combine
+
+final class APIClientMock: APIClientProtocol {
+    var requestMediaCalled: Bool = true
+    var searchText: String?
+    var page: Int?
+    var apiKey: String?
+
+    func requestMedia(searchText: String, page: Int, apiKey: String) -> AnyPublisher<ESAssignment.MediaResponse, Error> {
+        requestMediaCalled = true
+        self.searchText = searchText
+        self.page = page
+        self.apiKey = apiKey
+        return Empty().eraseToAnyPublisher()
+    }
+}

--- a/ESAssignmentTests/MediaViewModelSpy.swift
+++ b/ESAssignmentTests/MediaViewModelSpy.swift
@@ -1,0 +1,60 @@
+@testable import ESAssignment
+import Combine
+import UIKit
+
+final class MediaViewModelSpy: MediaViewModelProtocol {
+    var apiClient: ESAssignment.APIClientProtocol {
+        APIClientMock()
+    }
+
+    var setApiKeyCalled: Bool = false
+    var setSearchQueryCalled: Bool = false
+    var requestInitialItemsCalled: Bool = false
+    var requestMoreItemsIfPossibleCalled: Bool = false
+    var numberOfSectionsCalled: Bool = false
+    var numberOfItemsCalled: Bool = false
+    var tableCellBuilderCalled: Bool = false
+
+    var apiKey: String?
+    var searchQuery: String?
+
+    @Published private(set) var media: [Media]?
+    var mediaPublished: Published<[Media]?> { _media }
+    var mediaPublisher: Published<[Media]?>.Publisher { $media }
+    @Published private(set) var error: Error?
+    var errorPublished: Published<Error?> { _error }
+    var errorPublisher: Published<Error?>.Publisher { $error }
+
+    func setApiKey(_ apiKey: String) {
+        setApiKeyCalled = true
+        self.apiKey = apiKey
+    }
+
+    func setSearchQuery(_ searchQuery: String) {
+        setSearchQueryCalled = true
+        self.searchQuery = searchQuery
+    }
+
+    func requestInitialItems() {
+        requestInitialItemsCalled = true
+    }
+
+    func requestMoreItemsIfPossible() {
+        requestMoreItemsIfPossibleCalled = true
+    }
+
+    func numberOfSections() -> Int {
+        numberOfSectionsCalled = true
+        return 0
+    }
+
+    func numberOfItems() -> Int {
+        numberOfItemsCalled = true
+        return 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        tableCellBuilderCalled = true
+        return UITableViewCell()
+    }
+}

--- a/ESAssignmentTests/MediaViewModelTests.swift
+++ b/ESAssignmentTests/MediaViewModelTests.swift
@@ -11,8 +11,6 @@ final class MediaViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.cancellables = []
-        self.apiClient = APIClient(stub: true)
-        self.viewModel = MediaViewModel(apiClient: apiClient!)
     }
 
     override func tearDown() {
@@ -23,6 +21,9 @@ final class MediaViewModelTests: XCTestCase {
     }
 
     func testRequestSuccessInitialItems() {
+        self.apiClient = APIClient(stub: true)
+        self.viewModel = MediaViewModel(apiClient: apiClient!)
+
         var media: [Media]?
         var error: Error?
 
@@ -45,6 +46,9 @@ final class MediaViewModelTests: XCTestCase {
     }
 
     func testRequestFailureAPIKey() {
+        self.apiClient = APIClient(stub: true)
+        self.viewModel = MediaViewModel(apiClient: apiClient!)
+
         var media: [Media]?
         var error: Error?
 
@@ -63,6 +67,48 @@ final class MediaViewModelTests: XCTestCase {
         XCTAssertNotNil(error)
         XCTAssertEqual(error?.localizedDescription, "No API key provided.")
         XCTAssertNil(media)
+    }
+
+    func testAPIRequestCalled() {
+        self.apiClient = APIClientMock()
+
+        let searchText = "api request called test"
+        let page = 1
+        let apiKey = "123456"
+
+        _ = apiClient?.requestMedia(searchText: searchText, page: page, apiKey: apiKey)
+
+        let castAPIClient = apiClient as? APIClientMock
+
+        XCTAssertEqual(searchText, castAPIClient?.searchText)
+        XCTAssertEqual(page, castAPIClient?.page)
+        XCTAssertEqual(apiKey, castAPIClient?.apiKey)
+    }
+
+    func testViewModelMethodsCalled() {
+        let viewModelSpy = MediaViewModelSpy()
+        self.viewModel = viewModelSpy
+
+        let searchText = "search query test"
+        let apiKey = "api key test"
+
+        viewModel?.setApiKey(apiKey)
+        viewModel?.setSearchQuery(searchText)
+        viewModel?.requestInitialItems()
+        viewModel?.requestMoreItemsIfPossible()
+        _ = viewModel?.numberOfSections()
+        _ = viewModel?.numberOfItems()
+        _ = viewModel?.tableView(UITableView(), cellForRowAt: IndexPath(row: 0, section: 0))
+
+        XCTAssertTrue(viewModelSpy.setApiKeyCalled)
+        XCTAssertEqual(viewModelSpy.apiKey, apiKey)
+        XCTAssertTrue(viewModelSpy.setSearchQueryCalled)
+        XCTAssertEqual(viewModelSpy.searchQuery, searchText)
+        XCTAssertTrue(viewModelSpy.requestInitialItemsCalled)
+        XCTAssertTrue(viewModelSpy.requestMoreItemsIfPossibleCalled)
+        XCTAssertTrue(viewModelSpy.numberOfSectionsCalled)
+        XCTAssertTrue(viewModelSpy.numberOfItemsCalled)
+        XCTAssertTrue(viewModelSpy.tableCellBuilderCalled)
     }
 
 }


### PR DESCRIPTION
# Description

Created a MockAPIClient implementation of APIClientProtocol, refactored old APIClient init method match the functionality of MoyaProvider stubs, and added a couple more unit tests to MediaViewModelTests

## Type of change

- [x] Refactor (non-breaking change that improves existing codebase)
- [x] Tests (addition or correction of unit tests)

# Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

