### PR TITLE
Fix: fixed table view cells not being interactable

### DIFF
--- a/ESAssignment.xcodeproj/project.pbxproj
+++ b/ESAssignment.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A8B091082BEE6B8B0048A17C /* MediaViewControllerBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B091072BEE6B8B0048A17C /* MediaViewControllerBuilder.swift */; };
 		A8C597BD2BFDCF49005B2146 /* APIClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C597BC2BFDCF49005B2146 /* APIClientMock.swift */; };
 		A8C597BF2BFDCF60005B2146 /* MediaViewModelSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C597BE2BFDCF60005B2146 /* MediaViewModelSpy.swift */; };
+		A8C597C12BFDD189005B2146 /* MediaTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C597C02BFDD189005B2146 /* MediaTableView.swift */; };
 		A8D897002BED393B0011BA9A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D896FF2BED393B0011BA9A /* APIClient.swift */; };
 		A8D897022BED39630011BA9A /* OMDbProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D897012BED39630011BA9A /* OMDbProvider.swift */; };
 		A8D897052BED3BA80011BA9A /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D897042BED3BA80011BA9A /* Media.swift */; };
@@ -68,6 +69,7 @@
 		A8B091072BEE6B8B0048A17C /* MediaViewControllerBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewControllerBuilder.swift; sourceTree = "<group>"; };
 		A8C597BC2BFDCF49005B2146 /* APIClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientMock.swift; sourceTree = "<group>"; };
 		A8C597BE2BFDCF60005B2146 /* MediaViewModelSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewModelSpy.swift; sourceTree = "<group>"; };
+		A8C597C02BFDD189005B2146 /* MediaTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTableView.swift; sourceTree = "<group>"; };
 		A8D896FF2BED393B0011BA9A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		A8D897012BED39630011BA9A /* OMDbProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OMDbProvider.swift; sourceTree = "<group>"; };
 		A8D897042BED3BA80011BA9A /* Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				A80E311D2BED33C900730EDF /* MediaViewController.swift */,
 				A8D8970B2BED4ABA0011BA9A /* MediaView.swift */,
 				A8D8970D2BED57950011BA9A /* MediaTableCell.swift */,
+				A8C597C02BFDD189005B2146 /* MediaTableView.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -411,6 +414,7 @@
 				A8DB46612BEE818F0098CD19 /* OMDbProviderMock.swift in Sources */,
 				A8D8970C2BED4ABA0011BA9A /* MediaView.swift in Sources */,
 				A8B090F02BED8B080048A17C /* URLChecker.swift in Sources */,
+				A8C597C12BFDD189005B2146 /* MediaTableView.swift in Sources */,
 				A8D8970E2BED57950011BA9A /* MediaTableCell.swift in Sources */,
 				A8D897052BED3BA80011BA9A /* Media.swift in Sources */,
 				A8B090FC2BEE1FF70048A17C /* ErrorCell.swift in Sources */,

--- a/ESAssignment/Feature/Media/MediaTableCell.swift
+++ b/ESAssignment/Feature/Media/MediaTableCell.swift
@@ -22,8 +22,9 @@ final class MediaTableCell: UITableViewCell {
         let button = UIButton(frame: .zero)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle("Button", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.backgroundColor = .blue
+        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.white, for: .highlighted)
+        button.backgroundColor = .lightGray
         button.clipsToBounds = true
         button.layer.cornerRadius = 10.0
         return button
@@ -68,31 +69,31 @@ extension MediaTableCell: ViewCode {
     }
 
     func buildHierarchy() {
-        addSubview(posterImage)
-        addSubview(titleLabel)
-        addSubview(yearLabel)
-        addSubview(button)
+        contentView.addSubview(posterImage)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(yearLabel)
+        contentView.addSubview(button)
     }
 
     func buildConstraints() {
-        posterImage.topAnchor.constraint(equalTo: topAnchor, constant: 8.0).isActive = true
-        posterImage.leftAnchor.constraint(equalTo: leftAnchor, constant: 8.0).isActive = true
-        posterImage.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8.0).isActive = true
+        posterImage.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8.0).isActive = true
+        posterImage.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: 8.0).isActive = true
+        posterImage.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8.0).isActive = true
         let constraint = posterImage.heightAnchor.constraint(equalToConstant: 200.0)
         constraint.priority = .defaultHigh
         constraint.isActive = true
-        posterImage.widthAnchor.constraint(equalTo: heightAnchor, multiplier: 0.75).isActive = true
+        posterImage.widthAnchor.constraint(equalTo: posterImage.heightAnchor, multiplier: 0.75).isActive = true
 
-        titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 8.0).isActive = true
+        titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8.0).isActive = true
         titleLabel.leftAnchor.constraint(equalTo: posterImage.rightAnchor, constant: 8.0).isActive = true
-        titleLabel.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -8.0).isActive = true
+        titleLabel.rightAnchor.constraint(lessThanOrEqualTo: contentView.rightAnchor, constant: -8.0).isActive = true
 
         yearLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8.0).isActive = true
         yearLabel.leftAnchor.constraint(equalTo: titleLabel.leftAnchor).isActive = true
 
-        button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8.0).isActive = true
+        button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8.0).isActive = true
         button.leftAnchor.constraint(equalTo: titleLabel.leftAnchor).isActive = true
-        button.rightAnchor.constraint(equalTo: rightAnchor, constant: -8.0).isActive = true
+        button.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -8.0).isActive = true
     }
 
     func additionalConfiguration() {

--- a/ESAssignment/Feature/Media/MediaTableView.swift
+++ b/ESAssignment/Feature/Media/MediaTableView.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+final class MediaTableView: UITableView {
+    override func touchesShouldCancel(in view: UIView) -> Bool {
+        if view is UIButton {
+            return true
+        }
+        return super.touchesShouldCancel(in: view)
+    }
+}

--- a/ESAssignment/Feature/Media/MediaView.swift
+++ b/ESAssignment/Feature/Media/MediaView.swift
@@ -19,11 +19,12 @@ final class MediaView: UIView {
     }()
 
     lazy var tableView: UITableView = {
-        let tableView = UITableView(frame: .zero)
+        let tableView = MediaTableView(frame: .zero)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.allowsSelection = false
         tableView.rowHeight = UITableView.automaticDimension
         tableView.keyboardDismissMode = .onDrag
+        tableView.canCancelContentTouches = true
         return tableView
     }()
 


### PR DESCRIPTION
# Description

Applied a fix to table view cells' buttons not being interactable due to being included in the wrong view hierarchy (UITableViewCell's view intead of its contentView). 

Also added a different color for the button highlighted state, and applied a custom table view to detect scrolling gestures when a pan gesture is currently on the table view cell's button, to make the experience of scrolling more responsive.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

